### PR TITLE
Remove the prefix because router already adds it

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -21,11 +21,11 @@ function renderRoutes (routingStack, options) {
 function createRouteDescription (layer) {
   // TODO: Support sub-routers
 
-  const { methods, opts = {}, path } = layer
+  const { methods, path } = layer
 
   return {
     methods,
-    path,
+    path
   }
 }
 

--- a/lib/render.js
+++ b/lib/render.js
@@ -22,11 +22,10 @@ function createRouteDescription (layer) {
   // TODO: Support sub-routers
 
   const { methods, opts = {}, path } = layer
-  const absolutePath = opts.prefix + path
 
   return {
     methods,
-    path: absolutePath
+    path,
   }
 }
 


### PR DESCRIPTION
When I run this with a prefix. it shows the prefix twice... so I think koa-router already adds it